### PR TITLE
Add bin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ src/test/data/sandbox/
 # MacOS custom attributes files created by Finder
 .DS_Store
 docs/_site/
+
+/bin/


### PR DESCRIPTION
Adds the `bin/` directory (which is generated upon Gradle build) into the `.gitignore`.