### PR TITLE
Fix to disallow attaching of directories

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AttachCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttachCommand.java
@@ -70,6 +70,9 @@ public class AttachCommand extends Command {
         List<Attachment> updatedAttachments = new ArrayList<>(personToAttachTo.getAttachments());
         try {
             for (Attachment attachment : attachments) {
+                if (attachment.file.isDirectory()) {
+                    throw new CommandException(MESSAGE_FAILED_TO_COPY);
+                }
                 checkAttachmentUnique(attachment, updatedAttachments);
                 Attachment copiedAttachment = copyAttachment(
                         model.getUserPrefs().getAttachmentsBasePath(), attachment, personToAttachTo);


### PR DESCRIPTION
Don't allow the attaching of directories (current behaviour is to attach an empty directory to the `Person`).